### PR TITLE
Added global and block-level parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Role Variables
 --------------
 
 The variables that can be passed to this role and a brief description about
-them are as follows. These are all based on the configuration variales of the
+them are as follows. These are all based on the configuration variables of the
 DHCP server configuration.
 
     # Basic configuration information

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ DHCP server configuration.
     dhcp_common_log_facility: local7
     dhcp_common_options:
     - opt66 code 66 = string
+    dhcp_common_parameters:
+    - filename "pxelinux.0"
 
     # Subnet configuration
     dhcp_subnets:
@@ -49,9 +51,13 @@ DHCP server configuration.
       - range_start: 192.168.100.10
         range_end: 192.168.100.20
         rule: 'allow members of "foo"'
+        parameters:
+        - filename "pxelinux.0"
       - range_start: 192.168.110.10
         range_end: 192.168.110.20
         rule: 'deny members of "foo"'
+      parameters:
+      - filename "pxelinux.0"
 
     # Fixed lease configuration
     dhcp_hosts:
@@ -60,6 +66,8 @@ DHCP server configuration.
       fixed_address: 192.168.10.10
       default_lease_time: 43200
       max_lease_time: 86400
+      parameters:
+      - filename "pxelinux.0"
 
     # Class configuration
     dhcp_classes:
@@ -79,10 +87,14 @@ DHCP server configuration.
       - base: 192.168.100.0
         netmask: 255.255.255.0
         routers: 192.168.10.1
+      parameters:
+      - filename "pxelinux.0"
       pools:
       - range_start: 192.168.100.10
         range_end: 192.168.100.20
         rule: 'allow members of "foo"'
+        parameters:
+        - filename "pxelinux.0"
       - range_start: 192.168.110.10
         range_end: 192.168.110.20
         rule: 'deny members of "foo"'

--- a/templates/dhcpd.conf.j2
+++ b/templates/dhcpd.conf.j2
@@ -102,7 +102,7 @@ subnet {{ s.base }} netmask {{ s.netmask }} {
 {% endif %}
 {% if s.parameters is defined %}
 {% for p in s.parameters %}
-{{ p }};
+  {{ p }};
 {% endfor %}
 {% endif %}
 }
@@ -135,7 +135,7 @@ host {{ h.name }} {
 {% endif %}
 {% if h.parameters is defined %}
 {% for p in h.parameters %}
-{{ p }};
+  {{ p }};
 {% endfor %}
 {% endif %}
 }
@@ -187,7 +187,7 @@ shared-network {{ n.name }} {
 {% endfor %}
 {% if n.parameters is defined %}
 {% for p in n.parameters %}
-{{ p }};
+  {{ p }};
 {% endfor %}
 {% endif %}
 }

--- a/templates/dhcpd.conf.j2
+++ b/templates/dhcpd.conf.j2
@@ -39,6 +39,11 @@ log-facility {{ dhcp_common_log_facility }};
 option {{ o }};
 {% endfor %}
 
+#DHCP parameters
+{% for p in dhcp_common_parameters %}
+{{ p }};
+{% endfor %}
+
 # Classes
 {% for c in dhcp_classes %}
 class "{{ c.name }}" {
@@ -85,9 +90,15 @@ subnet {{ s.base }} netmask {{ s.netmask }} {
     {{ p.rule }};
 {% endif %}
     range {{ p.range_start }} {{ p.range_end }};
+{% for param in p.parameters %}
+    {{ param }};
+{% endfor %}
   }
 {% endfor %}
 {% endif %}
+{% for p in s.parameters %}
+{{ p }};
+{% endfor %}
 }
 {% endfor %}
 
@@ -116,6 +127,9 @@ host {{ h.name }} {
 {% if h.max_lease_time is defined %}
   max-lease-time {{ h.max_lease_time }};
 {% endif %}
+{% for p in h.parameters %}
+{{ p }};
+{% endfor %}
 }
 {% endfor %}
 
@@ -145,13 +159,22 @@ shared-network {{ n.name }} {
 {% if s.max_lease_time is defined %}
     max-lease-time {{ s.max_lease_time }};
 {% endif %}
+{% for param in s.parameters %}
+    {{ param }};
+{% endfor %}
   }
 {% endfor %}
 {% for p in n.pools %}
   pool {
     {{ p.rule }};
     range {{ p.range_start }} {{ p.range_end }};
+{% for param in p.parameters %}
+    {{ param }};
+{% endfor %}
   }
+{% endfor %}
+{% for p in n.parameters %}
+{{ p }};
 {% endfor %}
 }
 {% endfor %}

--- a/templates/dhcpd.conf.j2
+++ b/templates/dhcpd.conf.j2
@@ -40,9 +40,11 @@ option {{ o }};
 {% endfor %}
 
 #DHCP parameters
+{% if dhcp_common_parameters is defined %}
 {% for p in dhcp_common_parameters %}
 {{ p }};
 {% endfor %}
+{% endif %}
 
 # Classes
 {% for c in dhcp_classes %}
@@ -90,15 +92,19 @@ subnet {{ s.base }} netmask {{ s.netmask }} {
     {{ p.rule }};
 {% endif %}
     range {{ p.range_start }} {{ p.range_end }};
+{% if p.parameters is defined %}
 {% for param in p.parameters %}
     {{ param }};
 {% endfor %}
+{% endif %}
   }
 {% endfor %}
 {% endif %}
+{% if s.parameters is defined %}
 {% for p in s.parameters %}
 {{ p }};
 {% endfor %}
+{% endif %}
 }
 {% endfor %}
 
@@ -127,9 +133,11 @@ host {{ h.name }} {
 {% if h.max_lease_time is defined %}
   max-lease-time {{ h.max_lease_time }};
 {% endif %}
+{% if h.parameters is defined %}
 {% for p in h.parameters %}
 {{ p }};
 {% endfor %}
+{% endif %}
 }
 {% endfor %}
 
@@ -159,23 +167,29 @@ shared-network {{ n.name }} {
 {% if s.max_lease_time is defined %}
     max-lease-time {{ s.max_lease_time }};
 {% endif %}
+{% if s.parameters is defined %}
 {% for param in s.parameters %}
     {{ param }};
 {% endfor %}
+{% endif %}
   }
 {% endfor %}
 {% for p in n.pools %}
   pool {
     {{ p.rule }};
     range {{ p.range_start }} {{ p.range_end }};
+{% if p.parameters is defined %}
 {% for param in p.parameters %}
     {{ param }};
 {% endfor %}
+{% endif %}
   }
 {% endfor %}
+{% if n.parameters is defined %}
 {% for p in n.parameters %}
 {{ p }};
 {% endfor %}
+{% endif %}
 }
 {% endfor %}
 


### PR DESCRIPTION
Hi,

I decided to add free-form statements as described in dhcpd.conf(5), such as **next-server** and **filename**. If you find it useful, please feel free to pull commits. Thanks.