### PR TITLE
Make ansible managed optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ DHCP server configuration.
     configure_apparmor: true
 
     # Basic configuration information
+    dhcp_use_ansible_managed: true|false (default is true)
     dhcp_interfaces: eth0
     dhcp_common_domain: example.org
     dhcp_common_nameservers: ns1.example.org, ns2.example.org

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 configure_apparmor: false
 
 dhcp_interfaces: eth0
+dhcp_use_ansible_managed: true
 
 dhcp_subnets: []
 dhcp_hosts: []

--- a/templates/dhcpd.conf.j2
+++ b/templates/dhcpd.conf.j2
@@ -1,5 +1,5 @@
 ## dhcpd.conf
-# {{ ansible_managed }}
+{% if dhcp_use_ansible_managed %}# {{ ansible_managed }}{% endif %}
 # Do not edit manually
 
 {% if dhcp_omapi_port is defined %}


### PR DESCRIPTION
I just don't want ansible reporting a "change" every time the timestamp changes in a comment.